### PR TITLE
Fix: remove letter spacing from body style

### DIFF
--- a/packages/app-theme-mui/src/theme.ts
+++ b/packages/app-theme-mui/src/theme.ts
@@ -209,7 +209,6 @@ export const createThemeProvider = ({
             body: {
               fontSize: '0.875rem',
               lineHeight: 1.43,
-              letterSpacing: '0.01071em',
             },
           },
         },


### PR DESCRIPTION
It was added only because of [this upgrade step](https://mui.com/material-ui/migration/v5-component-changes/#update-body-font-size), but apparently it's incorrect and shouldn't have been added.