### PR TITLE
Fix: use the disabled color for the :selected:disabled state of ToggleButton

### DIFF
--- a/packages/app-theme-mui/src/theme.ts
+++ b/packages/app-theme-mui/src/theme.ts
@@ -319,6 +319,16 @@ export const createThemeProvider = ({
           },
         }),
 
+        MuiToggleButton: {
+          styleOverrides: {
+            root: {
+              '&.Mui-selected:disabled': {
+                color: baseTheme.palette.action.disabled,
+              },
+            },
+          },
+        },
+
         // Captions should be mapped to a <div> tag, not to a <span>
         // (Material UI v4 compatibility)
         MuiTypography: muiV4Compat({


### PR DESCRIPTION
The problem: the selected state adds the `color: "fff"` style, and this remains the active style even if the button is disabled.

The fix: explicitly use the disabled color for the `:selected:disabled` state.

Where is this needed: in Live (with mui v5) it fixes the appearance of toggle buttons in the top right corner of the UAVs panel (in `MappingButtonGroup`).