### PR TITLE
feat: add startTime field to AudioData

### DIFF
--- a/packages/show-format/src/types.ts
+++ b/packages/show-format/src/types.ts
@@ -188,7 +188,7 @@ export type AudioData = {
   mediaType: 'audio/mpeg';
 
   /** Start time of the audio relative to the show start, in seconds. */
-  startTime: number;
+  startTime?: number;
 };
 
 /**

--- a/packages/show-format/src/types.ts
+++ b/packages/show-format/src/types.ts
@@ -186,6 +186,9 @@ export type AudioData = {
 
   /** MIME media type of the audio data. Currently we support MPEG only. */
   mediaType: 'audio/mpeg';
+
+  /** Start time of the audio relative to the show start, in seconds. */
+  startTime: number;
 };
 
 /**


### PR DESCRIPTION
This PR updates the `AudioData` field of the show format with the following:

- [x] add `startTime`
- [x] ~~harmonize `data` + `filename` fields with private file format specification and `skybrush-studio` backend~~